### PR TITLE
Relax upper bounds of primitive and vector package to allow primitive-0.6 and vector-0.11

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -45,8 +45,8 @@ Source-repository head
 Library
   Build-Depends:
       base      >= 3   && < 5
-    , primitive >= 0.2 && < 0.5
-    , vector    >= 0.5 && < 0.10
+    , primitive >= 0.2 && < 0.7
+    , vector    >= 0.5 && < 0.12
   Exposed-Modules:
     Numeric.Optimization.Algorithms.HagerZhang05
   Include-Dirs:


### PR DESCRIPTION
This relaxes upper bounds of primitive and vector package to allow primitive-0.6 and vector-0.11.
I have confirmed that it works fine with these version on GHC-7.8.3.
