### PR TITLE
Relax upper bound of vector package to allow vector-0.12

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -46,7 +46,7 @@ Library
   Build-Depends:
       base      >= 3   && < 5
     , primitive >= 0.2 && < 0.7
-    , vector    >= 0.5 && < 0.12
+    , vector    >= 0.5 && < 0.13
   Exposed-Modules:
     Numeric.Optimization.Algorithms.HagerZhang05
   Include-Dirs:


### PR DESCRIPTION
This relaxes upper bound of vector package to allow vector-0.12.
I have confirmed that it works fine with the version on GHC-8.2.2 and Stackage LTS 10.4.
