### PR TITLE
Relax upper bound of primitive package to allow primitive-0.7.0.0

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -44,7 +44,7 @@ Source-repository head
 Library
   Build-Depends:
       base      >= 3   && < 5
-    , primitive >= 0.2 && < 0.7
+    , primitive >= 0.2 && < 0.8
     , vector    >= 0.5 && <= 0.13
   Exposed-Modules:
     Numeric.Optimization.Algorithms.HagerZhang05


### PR DESCRIPTION
This relaxes upper bound of vector package to allow primitive-0.7.0.0.

I have confirmed that it can be built with Stackage LTS 14.20 + `primitive-0.7.0.0` extra-deps.