### PR TITLE
update CG_DESCENT-C-3.0.tar.gz URL

### DIFF
--- a/src/Numeric/Optimization/Algorithms/HagerZhang05.hsc
+++ b/src/Numeric/Optimization/Algorithms/HagerZhang05.hsc
@@ -17,7 +17,7 @@
 --   /search./ Society of Industrial and Applied Mathematics
 --   Journal on Optimization, 16 (2005), 170-192.
 --
--- * [2] <http://www.math.ufl.edu/~hager/papers/CG/CG_DESCENT-C-3.0.tar.gz>
+-- * [2] <https://www.math.lsu.edu/~hozhang/SoftArchive/CG_DESCENT-C-3.0.tar.gz>
 --
 --------------------------------------------------------------------------
 


### PR DESCRIPTION
I confirmed that contents of `CG_DESCENT-C-3.0` directory is a subset of https://www.math.lsu.edu/~hozhang/SoftArchive/CG_DESCENT-C-3.0.tar.gz (the tarball contains `CUTEr_interface`, `Makefile`, `driver1.c`, `driver2.c`, `driver3.c`, `driver4.c`, `driver5.c` in addition to the contents of `CG_DESCENT-C-3.0` directory).

fixes #3 