### PR TITLE
add links to nonlinear-optimization-ad and nonlinear-optimization-backprop on nonlinear-optimization.cabal

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -27,6 +27,11 @@ Description:
     @hmatrix@ easily.
     .
     Currently only CG_DESCENT method is implemented.
+    .
+    If you want to use automatic differentiation to avoid hand-writing gradient functions,
+    you can use
+    <https://hackage.haskell.org/package/nonlinear-optimization-ad nonlinear-optimization-ad> package or
+    <https://hackage.haskell.org/package/nonlinear-optimization-backprop nonlinear-optimization-backprop> package.
 Extra-Source-Files:
     CG_DESCENT-C-3.0/cg_descent.c,
     CG_DESCENT-C-3.0/cg_descent.h,


### PR DESCRIPTION
I'm developing [nonlinear-optimization-ad](https://hackage.haskell.org/package/nonlinear-optimization-ad) and [nonlinear-optimization-backprop](https://hackage.haskell.org/package/nonlinear-optimization-backprop) for combining automatic differentiation with `nonlinear-optimization` package, and it might be useful for users to add information of those package on `nonlinear-optimization` package description.