### PR TITLE
add Homepage and Bug-Reports sections to nonlinear-optimization.cabal

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -27,6 +27,8 @@ Description:
     @hmatrix@ easily.
     .
     Currently only CG_DESCENT method is implemented.
+Homepage:	https://github.com/meteficha/nonlinear-optimization
+Bug-Reports:	https://github.com/meteficha/nonlinear-optimization/issues
 Extra-Source-Files:
     CG_DESCENT-C-3.0/cg_descent.c,
     CG_DESCENT-C-3.0/cg_descent.h,


### PR DESCRIPTION
How about adding `Homepage` and `Bug-Reports` sections to `nonlinear-optimization.cabal`?