### PR TITLE
Relax upper bound of vector package to allow vector-0.13.0.0

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -52,7 +52,7 @@ Library
   Build-Depends:
       base      >= 3   && < 5
     , primitive >= 0.2 && < 0.8
-    , vector    >= 0.5 && <= 0.13
+    , vector    >= 0.5 && <= 0.14
   Exposed-Modules:
     Numeric.Optimization.Algorithms.HagerZhang05
   Include-Dirs:


### PR DESCRIPTION
This relaxes upper bound of vector package to allow vector-0.13.0.0.

I have confirmed that it can be built with the following `stack.yaml`

```yaml
resolver: nightly-2022-08-19
extra-deps:
- vector-0.13.0.0
- vector-stream-0.1.0.0@sha256:09b0f8dc4e51936b9d6b04791f0aa03f7c9759b5fb7140eac8a9461cda1e55a3,1404
```