### PR TITLE
Specify 'cabal-version: >= 1.8' to use version operators

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:       >= 1.6
+Cabal-Version:       >= 1.8
 Build-Type:          Simple
 Tested-With:         GHC
 Category:            Math


### PR DESCRIPTION
This fixes the following warnings by `stack build`.

```
Warning: nonlinear-optimization.cabal:53:26: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
Warning: nonlinear-optimization.cabal:54:26: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
Warning: nonlinear-optimization.cabal:55:26: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
```
