### PR TITLE
Relax upper bound of primitive package to allow primitive-0.8.0.0

### DIFF
--- a/nonlinear-optimization.cabal
+++ b/nonlinear-optimization.cabal
@@ -51,7 +51,7 @@ Source-repository head
 Library
   Build-Depends:
       base      >= 3   && < 5
-    , primitive >= 0.2 && < 0.8
+    , primitive >= 0.2 && < 0.9
     , vector    >= 0.5 && <= 0.14
   Exposed-Modules:
     Numeric.Optimization.Algorithms.HagerZhang05


### PR DESCRIPTION
This relaxes the upper bound of the primitive package to allow primitive-0.8.0.0.

I have confirmed that it can be built with the following `stack.yaml`

```yaml
resolver: nightly-2023-05-08
```